### PR TITLE
Get java driver to temporarily use kernel extension & neo4j server for ITs

### DIFF
--- a/driver/pom.xml
+++ b/driver/pom.xml
@@ -61,6 +61,12 @@ the relevant Commercial Agreement.
       <artifactId>mockito-all</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.rauschig</groupId>
+      <artifactId>jarchivelib</artifactId>
+      <version>0.5.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
@@ -96,25 +102,6 @@ the relevant Commercial Agreement.
           <execution>
             <goals>
               <goal>test-jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-failsafe-plugin</artifactId>
-        <configuration>
-          <environmentVariables>
-            <neo4j.artifactUrl>file:${project.basedir}/../neo4j-driver-test-server-${neo4j.version}.jar</neo4j.artifactUrl>
-          </environmentVariables>
-        </configuration>
-        <executions>
-          <execution>
-            <goals>
-              <goal>integration-test</goal>
-              <goal>verify</goal>
             </goals>
           </execution>
         </executions>

--- a/driver/src/test/java/org/neo4j/driver/stress/DriverStresser.java
+++ b/driver/src/test/java/org/neo4j/driver/stress/DriverStresser.java
@@ -19,6 +19,7 @@
  */
 package org.neo4j.driver.stress;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -43,7 +44,7 @@ public class DriverStresser
     {
         int iterations = 100_000;
 
-        bench( (long) iterations, 1, 10_000 );
+        bench( iterations, 1, 10_000 );
         bench( (long) iterations / 2, 2, 10_000 );
         bench( (long) iterations / 4, 4, 10_000 );
         bench( (long) iterations / 8, 8, 10_000 );
@@ -81,7 +82,7 @@ public class DriverStresser
         }
     }
 
-    public static void teardown() throws InterruptedException
+    public static void teardown() throws IOException
     {
         server.stopServer();
     }


### PR DESCRIPTION
The kernel extension and neo4j server will be downloaded remotely using URLs.
After the download, the neo4j server will be configured locally to enable ndp extension.
The server is started and stopped using neo4j scripts.